### PR TITLE
Poper active class with query string + Fix for multiple menu's

### DIFF
--- a/controllers/Olivemenus_MenuitemController.php
+++ b/controllers/Olivemenus_MenuitemController.php
@@ -27,7 +27,7 @@ class Olivemenus_MenuitemController extends BaseController
 				
 				foreach ( $menu_items as $element )
 				{
-					if ( isset($element['item-id']) && $element['item-id'] == $parent_id )
+                    if ( isset($element['item-id']['html']) && $element['item-id']['html'] == $parent_id )
 					{
 						$parent_id = $element['menu-item-db-id'];
 						$menu_items[$order]['parent-id'] = $parent_id;
@@ -52,8 +52,11 @@ class Olivemenus_MenuitemController extends BaseController
 
             $data_json = '';
             if ( isset($menu_item['data-json']) ) $data_json = $menu_item['data-json'];
-            
-            $menu_item_model->id = $menu_item['item-id'];
+
+            $menu_item_model->id = null;
+            if($menu_item['item-id']['db'] != null){
+                $menu_item_model->id = $menu_item['item-id']['db'];
+            }
             $menu_item_model->menu_id = $menu_id;
             $menu_item_model->parent_id = $parent_id;
             $menu_item_model->item_order = $order;

--- a/resources/js/jquery-custom.js
+++ b/resources/js/jquery-custom.js
@@ -261,10 +261,10 @@ $(document).ready(function(){
 				
 				if ( typeof menuItem.id !== 'undefined' )
 				{
-					
-					var menuItemID = menuItem.id,
-						menuItemParentID = (typeof menuItem.parent_id !== null ) ? menuItem.parent_id : 0,
-						menuItemElement = $('#menu-item-' + menuItemID),
+
+					var menuItemParentID = (typeof menuItem.parent_id !== null ) ? menuItem.parent_id : 0,
+						menuItemElement = $('#menu-item-' + menuItem.id),
+						menuItemID = menuItemElement.find('input[name="item-id"]'),
 						menuItemNameElement = menuItemElement.find('input[name="item-name"]'),
 						menuItemNameValue = menuItemNameElement.val(),
 						menuItemEntryIDElement = menuItemElement.find('input[name="item-entry-id"]'),
@@ -276,10 +276,19 @@ $(document).ready(function(){
                         menuItemClassParentElement = menuItemElement.find('input[name="class-parent"]'),
 						menuItemClassParentValue = menuItemClassParentElement.val(),
                         menuItemDataElement = menuItemElement.find('textarea[name="data-json"]'),
-						menuItemDataValue = menuItemDataElement.val();						
-									
+						menuItemDataValue = menuItemDataElement.val();
+
+					if(menuItemID.length == 0){
+						menuItemID = null;
+					} else {
+						menuItemID = menuItemID.val();
+					}
+
 					var menuItemData = {
-						'item-id' : menuItemID,
+						'item-id' : {
+							db:menuItemID,
+							html:menuItem.id
+						},
 						'parent-id' : menuItemParentID,
 						'name' : menuItemNameValue,
 						'entry-id' : menuItemEntryIDValue,

--- a/services/OlivemenusService.php
+++ b/services/OlivemenusService.php
@@ -211,6 +211,7 @@ class OlivemenusService extends BaseApplicationComponent
         if ( $current_active_url != '' && $menu_item_url != '' )
         {
             $menu_item_url_filtered = preg_replace('#^https?://#', '', $menu_item_url);
+            $current_active_url = preg_replace('/\?.*/', '', $current_active_url); // Remove query string
             if ( $current_active_url == $menu_item_url_filtered )
             {
                 $menu_class .= ' active';

--- a/services/Olivemenus_MenuitemsService.php
+++ b/services/Olivemenus_MenuitemsService.php
@@ -140,6 +140,7 @@ class Olivemenus_MenuitemsService extends BaseApplicationComponent
                     $localHTML .= '<span class="delete-menu btn small" data-id="' .$menu_item['id']. '">Delete</span>';
                 $localHTML .= '</div>';
                 $localHTML .= '<div class="item-content">';
+                $localHTML .= '<input type="hidden" name="item-id" value="' .$menu_item['id']. '" />';
                     if ( $menu_item['custom_url'] == '' ) $localHTML .= '<input type="hidden" name="item-entry-id" value="' .$menu_item['entry_id']. '" />';                
                     $localHTML .= '<div class="inner">';
                         $localHTML .= '<div class="row field">';


### PR DESCRIPTION
- I added a line of code that removes the query string from the url so the active class will be added anyways.
- There also was an issue with multiple menu's where the ids were overridden in the DB because the item IDs from the frontend were being used instead of the id's.** This is fixed now.

** You can test this by reinstalling the plugin so the DB is clean. Then you make 2 menu's and select for both those menu's the same things. The items on the menu will be transfered to the other.