### PR TITLE
Updated custom menu items

### DIFF
--- a/controllers/Olivemenus_MenuitemController.php
+++ b/controllers/Olivemenus_MenuitemController.php
@@ -41,8 +41,7 @@ class Olivemenus_MenuitemController extends BaseController
             $entry_id = '';
             if ( isset($menu_item['entry-id']) ) $entry_id = $menu_item['entry-id'];
 
-            $custom_url = '';
-            if ( !isset($menu_item['entry-id']) && isset($menu_item['custom-url']) ) $custom_url = $menu_item['custom-url'];
+            $custom_url = $menu_item['custom-url'];
 
             $class = '';
             if ( isset($menu_item['class']) ) $class = $menu_item['class'];

--- a/resources/js/jquery-custom.js
+++ b/resources/js/jquery-custom.js
@@ -171,10 +171,9 @@ $(document).ready(function(){
                 customMenuTitle.removeClass('error');
                 customMenuURL.removeClass('error');
 
-                if ( customMenuTitleVal == '' || customMenuURLVal == '' )
+                if ( customMenuTitleVal == '' )
                 {
                     if ( customMenuTitleVal == '' ) customMenuTitle.addClass('error');
-                    if ( customMenuURLVal == '' ) customMenuURL.addClass('error');
                 }
                 else
                 {

--- a/services/OlivemenusService.php
+++ b/services/OlivemenusService.php
@@ -233,8 +233,17 @@ class OlivemenusService extends BaseApplicationComponent
         
         $localHTML = '';
         $localHTML .= '<li id="menu-item-' .$menu_item['id']. '" class="' .$menu_item_class. '">';
+
+        	if ($menu_item_url) {
+        		$localHTML .= '<a class="'. $menu_class. '" href="' .$menu_item_url. '"' .$data_attributes. '>' . Craft::t( $menu_item['name'] ) . '</a>';
+        	} else {
+        		$localHTML .= '<span class="'. $menu_class. '"' .$data_attributes. '>' . Craft::t( $menu_item['name'] ) . '</span>';
+        	}
             
-            $localHTML .= '<a class="'. $menu_class. '" href="' .$menu_item_url. '"' .$data_attributes. '>' . Craft::t( $menu_item['name'] ) . '</a>';
+            
+
+
+
             if ( isset($menu_item['children']) )
             {
                 $localHTML .= '<ul class="sub-menu">';

--- a/services/Olivemenus_MenuitemsService.php
+++ b/services/Olivemenus_MenuitemsService.php
@@ -151,17 +151,14 @@ class Olivemenus_MenuitemsService extends BaseApplicationComponent
                                 $localHTML .= '<input class="text nicetext fullwidth" type="text" name="item-name" value="' .$menu_item['name']. '" />';
                             $localHTML .= '</div>';
 						$localHTML .= '</div>';
-                        if ( $menu_item['custom_url'] != '' )
-                        {
-                            $localHTML .= '<div class="row field">';
-                                $localHTML .= '<div class="heading">';
-                                    $localHTML .= '<label>Custom URL:</label>';
-                                $localHTML .= '</div>';
-                                $localHTML .= '<div class="input">';
-                                    $localHTML .= '<input class="text nicetext fullwidth" type="text" name="custom-url" value="' .$menu_item['custom_url']. '" />';
-                                $localHTML .= '</div>';
+                        $localHTML .= '<div class="row field">';
+                            $localHTML .= '<div class="heading">';
+                                $localHTML .= '<label>Custom URL:</label>';
                             $localHTML .= '</div>';
-                        }						
+                            $localHTML .= '<div class="input">';
+                                $localHTML .= '<input class="text nicetext fullwidth" type="text" name="custom-url" value="' .$menu_item['custom_url']. '" />';
+                            $localHTML .= '</div>';
+                        $localHTML .= '</div>';
 						$localHTML .= '<div class="row field">';
                             $localHTML .= '<div class="heading">';
                                 $localHTML .= '<label>Class:</label>';

--- a/templates/_menu-container-items.html
+++ b/templates/_menu-container-items.html
@@ -193,7 +193,7 @@
                         <div class="fields-custom">
                             <div class="field">
                                 <div class="heading">
-                                    <label class="required" for="custom-menu-title">Link text</label>
+                                    <label class="required" for="custom-menu-title">Item text</label>
                                 </div>
                                 <div class="input">
                                     <input id="custom-menu-title" class="text nicetext fullwidth" type="text" />
@@ -201,7 +201,7 @@
                             </div>
                             <div class="field">
                                 <div class="heading">
-                                    <label class="required" for="custom-menu-url">URL</label>
+                                    <label for="custom-menu-url">URL</label>
                                 </div>
                                 <div class="input">
                                     <input id="custom-menu-url" class="text nicetext fullwidth" type="text" />


### PR DESCRIPTION
Updated custom menu items to support blank menu items (useful for submenus).

Seems to also fix a bug where when using a custom menu item with a href of `#` caused it to inherit it's first childs url when creating a sub menu and saving.