### PR TITLE
Deleted sections excluded from listing in olivemenu admin

### DIFF
--- a/src/services/OlivemenuItemsService.php
+++ b/src/services/OlivemenuItemsService.php
@@ -157,21 +157,21 @@ class OlivemenuItemsService extends Component
             ->select(["name AS name", "handle AS handle"])
             ->from(['{{%sections}}'])
             ->orderBy('name')
-            ->where(['type' => 'single'])
+            ->where(['type' => 'single', 'dateDeleted'=>NULL])
             ->all();
 
         $sections['structure'] = (new \craft\db\Query())
             ->select(["name AS name", "handle AS handle"])
             ->from(['{{%sections}}'])
             ->orderBy('name')
-            ->where(['type' => 'structure'])
+            ->where(['type' => 'structure', 'dateDeleted'=>NULL])
             ->all();
 
         $sections['channel'] = (new \craft\db\Query())
             ->select(["name AS name", "handle AS handle"])
             ->from(['{{%sections}}'])
             ->orderBy('name')
-            ->where(['type' => 'channel'])
+            ->where(['type' => 'channel', 'dateDeleted'=>NULL])
             ->all();
 
         return $sections;


### PR DESCRIPTION
…Service file
**Issue:** Even though sections are deleted in admin in craft CMS 3, those were still listing in olive menu admin section. 
<img width="226" alt="deleted-sections-listed" src="https://user-images.githubusercontent.com/6858928/71651419-588f4880-2d45-11ea-8c5d-886e171816ad.png">
**Fix:** Those deleted sections are excluded by updating condition in function: getSections 
<img width="221" alt="correct-sections-listed" src="https://user-images.githubusercontent.com/6858928/71651445-a3a95b80-2d45-11ea-8a54-3c3e7da30a94.png">


