### PR TITLE
Add a function to get the menu as data not HTML.

### DIFF
--- a/src/services/OlivemenusService.php
+++ b/src/services/OlivemenusService.php
@@ -250,4 +250,21 @@ class OlivemenusService extends Component
             return str_replace(array_keys($environmentVariables), array_values($environmentVariables), $str);
         }
     }
+
+    /**
+     * getMenuData
+     * Gets the menu data from olivemenus as a data instead of HTML.
+     * This way you can do your own HTML etc in Twig if you want to.
+     *
+     * @param  String $handle The handle of the menu item.
+     * @return Mixed The menu data as an array or a String warning that the menu doesn't exist.
+     */
+    public function getMenuData($handle) {
+      if ($handle === false || ($menu = $this->getMenuByHandle($handle)) === null) {
+        echo '<p>' . Craft::t('olivemenus', 'A menu with this handle does not exist!') . '</p>';
+        return;
+      }
+
+      return Olivemenus::$plugin->olivemenuItems->getMenuItems($menu->id);
+    }
 }

--- a/src/variables/OlivemenusVariable.php
+++ b/src/variables/OlivemenusVariable.php
@@ -54,4 +54,21 @@ class OlivemenusVariable
             return Olivemenus::$plugin->olivemenus->getMenuHTML($handle, $config);
         }
     }
+
+    /**
+     * From any Twig template, call it like this:
+     *
+     *     {{ craft.olivemenus.getMenuData(menuHandle) }}
+     *
+     * @param String $handle The handle of the menu you want the data for.
+     *
+     * @return Mixed The data of the menu you wrote or a string with a notice.
+     */
+
+    public function getMenuData($handle)
+    {
+      if ($handle != '') {
+          return Olivemenus::$plugin->olivemenus->getMenuData($handle);
+      }
+    }
 }


### PR DESCRIPTION
I saw in Issue #50 someone asking for custom walker functionality and I needed this earlier today too.

I appreciate you're likely busy so I've added a couple of functions to return the data only from the plugin as opposed to the full blown HTML so that people can do their own twig in their templates if they require.